### PR TITLE
Fix viewlet-ordering bug

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add simplelayout.base.listingPortlet.body viewlet to a viewlet order manager
+  to fix ordering bug when ordering viewlets in relation with this viewlet.
+  [elioschmutz]
 
 
 1.2.1 (2013-05-24)

--- a/simplelayout/portlet/dropzone/profiles/default/viewlets.xml
+++ b/simplelayout/portlet/dropzone/profiles/default/viewlets.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object>
+    <order manager="simplelayout.portlet.listing" skinname="*">
+     <viewlet name="simplelayout.base.listingPortlet.body" />
+    </order>
+</object>


### PR DESCRIPTION
@jone 
- Add simplelayout.base.listingPortlet.body viewlet to a viewlet order manager
  to fix ordering bug when ordering viewlets in relation with this viewlet.
